### PR TITLE
敵軍に攻撃された時の戦闘情報表示が逆転している事象を再度修正

### DIFF
--- a/簡易戦闘で詳細情報を表示する.js
+++ b/簡易戦闘で詳細情報を表示する.js
@@ -32,17 +32,17 @@ var EasyAttackInfoWindow = defineObject(BaseWindow, {
 	_leftInfo: null,
 	_rightInfo: null,
 
-	setInfo: function (leftUnit, rightUnit) {
-		// leftUnit　攻撃する側　rightUnit：攻撃される側
+	setInfo: function (attackUnit, targetUnit) {
+		// attackUnit　攻撃する側　targetUnit：攻撃される側
 		var attackInfo = this.getParentInstance().getAttackInfo();
-		var leftWeapon = BattlerChecker.getRealBattleWeapon(leftUnit);
-		var rightWeapon = BattlerChecker.getRealBattleWeapon(rightUnit);
+		var attackWeapon = BattlerChecker.getRealBattleWeapon(attackUnit);
+		var targetWeapon = BattlerChecker.getRealBattleWeapon(targetUnit);
 		// isUnitSrcPriority…優先位置表示対象(ウインドウ左側に出す)か否か
 		// 左側表示の優先順位は下記の法則に従う(singleton-system.js参照)
 		// 自軍 > 敵軍
 		// 自軍 > 同盟軍
 		// 同盟軍 > 敵軍
-		var isUnitSrcPriority = Miscellaneous.isUnitSrcPriority(leftUnit, rightUnit);
+		var isUnitSrcPriority = Miscellaneous.isUnitSrcPriority(attackUnit, targetUnit);
 		var enabledLeftAttack = isUnitSrcPriority || attackInfo.isCounterattack;
 		var enabledRightAttack = !isUnitSrcPriority || attackInfo.isCounterattack;
 		// 攻撃可能なら、攻撃する側が優先表示対象(Priority:true)かを判定する。
@@ -50,22 +50,22 @@ var EasyAttackInfoWindow = defineObject(BaseWindow, {
 		// 優先表示対象でない場合、攻撃される側の戦闘情報を表示する。
 		var leftStatuses = enabledLeftAttack
 			? (isUnitSrcPriority 
-				? AttackChecker.getAttackStatusInternal(leftUnit, leftWeapon, rightUnit)
-				: AttackChecker.getAttackStatusInternal(rightUnit, rightWeapon, leftUnit))
+				? AttackChecker.getAttackStatusInternal(attackUnit, attackWeapon, targetUnit)
+				: AttackChecker.getAttackStatusInternal(targetUnit, targetWeapon, attackUnit))
 			: AttackChecker.getNonStatus();
 		// 右側表示の場合は、優先位置である左側とは逆の条件で判定する。
 		var rightStatuses = enabledRightAttack
 			? (!isUnitSrcPriority
-				? AttackChecker.getAttackStatusInternal(leftUnit, leftWeapon, rightUnit)
-				: AttackChecker.getAttackStatusInternal(rightUnit, rightWeapon, leftUnit))
+				? AttackChecker.getAttackStatusInternal(attackUnit, attackWeapon, targetUnit)
+				: AttackChecker.getAttackStatusInternal(targetUnit, targetWeapon, attackUnit))
 			: AttackChecker.getNonStatus();
 
 		this._leftInfo = {
-			unit: leftUnit,
+			unit: attackUnit,
 			statuses: leftStatuses
 		};
 		this._rightInfo = {
-			unit: rightUnit,
+			unit: targetUnit,
 			statuses: rightStatuses
 		};
 	},

--- a/簡易戦闘で詳細情報を表示する.js
+++ b/簡易戦闘で詳細情報を表示する.js
@@ -33,17 +33,31 @@ var EasyAttackInfoWindow = defineObject(BaseWindow, {
 	_rightInfo: null,
 
 	setInfo: function (leftUnit, rightUnit) {
+		// leftUnit　攻撃する側　rightUnit：攻撃される側
 		var attackInfo = this.getParentInstance().getAttackInfo();
 		var leftWeapon = BattlerChecker.getRealBattleWeapon(leftUnit);
 		var rightWeapon = BattlerChecker.getRealBattleWeapon(rightUnit);
+		// isUnitSrcPriority…優先位置表示対象(ウインドウ左側に出す)か否か
+		// 左側表示の優先順位は下記の法則に従う(singleton-system.js参照)
+		// 自軍 > 敵軍
+		// 自軍 > 同盟軍
+		// 同盟軍 > 敵軍
 		var isUnitSrcPriority = Miscellaneous.isUnitSrcPriority(leftUnit, rightUnit);
 		var enabledLeftAttack = isUnitSrcPriority || attackInfo.isCounterattack;
 		var enabledRightAttack = !isUnitSrcPriority || attackInfo.isCounterattack;
+		// 攻撃可能なら、攻撃する側が優先表示対象(Priority:true)かを判定する。
+		// 優先表示対象の場合、攻撃する側の戦闘情報を表示し、
+		// 優先表示対象でない場合、攻撃される側の戦闘情報を表示する。
 		var leftStatuses = enabledLeftAttack
-			? AttackChecker.getAttackStatusInternal(leftUnit, leftWeapon, rightUnit)
+			? (isUnitSrcPriority 
+				? AttackChecker.getAttackStatusInternal(leftUnit, leftWeapon, rightUnit)
+				: AttackChecker.getAttackStatusInternal(rightUnit, rightWeapon, leftUnit))
 			: AttackChecker.getNonStatus();
+		// 右側表示の場合は、優先位置である左側とは逆の条件で判定する。
 		var rightStatuses = enabledRightAttack
-			? AttackChecker.getAttackStatusInternal(rightUnit, rightWeapon, leftUnit)
+			? (!isUnitSrcPriority
+				? AttackChecker.getAttackStatusInternal(leftUnit, leftWeapon, rightUnit)
+				: AttackChecker.getAttackStatusInternal(rightUnit, rightWeapon, leftUnit))
 			: AttackChecker.getNonStatus();
 
 		this._leftInfo = {


### PR DESCRIPTION
AttackChecker.getAttackStatusInternal ～Statusesに格納する戦闘情報ですがまだ入れ替わったままでしたので直しました。

(leftUnitは攻撃する側、 rightUnitは攻撃される側のユニット情報が渡されるようですね…)

検証環境：SRPG Studio ver.1.263
